### PR TITLE
Expressions escaping from lexical scopes are contained in closures

### DIFF
--- a/robert-dodier/lexical_symbols/rtest_lexical_symbols.mac
+++ b/robert-dodier/lexical_symbols/rtest_lexical_symbols.mac
@@ -1138,3 +1138,24 @@ gg(foo,bar)   /* fails, define gradient for f, not foo */
  */
  
 /* #summationindexscope */
+
+/* inspired by
+
+     (let ((name '+))
+       (let ((+ *))
+         (evaluate (list name 2 3))))
+
+   in: https://en.wikipedia.org/wiki/Scheme_(programming_language)#Lambda_calculus
+ */
+
+(kill (plus, times, name),
+ plus: lambda ([a, b], a + b),
+ times: lambda ([a, b], a * b),
+ block ([name: 'plus], block ([plus: 'times], ?meval (funmake (name, [2, 3])))));
+5;
+
+/* substitution into lambda should fail
+ * e.g. block([a], lambda([v], subst('v=v, lambda([v],a*v))));
+ * doesn't change inner lambda
+ */
+

--- a/robert-dodier/lexical_symbols/with-lexical-environment.lisp
+++ b/robert-dodier/lexical_symbols/with-lexical-environment.lisp
@@ -1,26 +1,54 @@
-;; List of active lexical environments.
+;; List of active lexical environments;
+;; the innermost environment is the first element.
 ;; Each environment is a hash table.
 ;; These are stored as the ENV property on a symbol.
 
 (defvar *active-lexical-environments* nil)
 
-(defmacro with-lexical-environment (env-list &rest body)
+(defmacro with-lexical-environment (env-name-list &rest body)
   `(let (symbols vals)
-    (mapcar #'(lambda (env) (maphash #'(lambda (s v) (push s symbols) (push v vals)) env)) ,env-list)
+    ;; If some of the environments named by ENV-NAME-LIST are already active,
+    ;; we don't need to bind those symbols. 
+    ;; Hpwever, that's doesn't change the behavior of WITH-LEXICAL-ENVIRONMENT,
+    ;; so let's do it the simpler way for now. !!
+    (mapcar #'(lambda (env-name) (maphash #'(lambda (s v) (push s symbols) (push v vals)) (get env-name 'env))) ,env-name-list)
     (mbind symbols vals nil)
-    (unwind-protect (meval (list '(mprogn) ,@body))
-      (mapcar #'(lambda (env) (maphash #'(lambda (s v) (setf (gethash s env) (symbol-value s))) env)) ,env-list)
+    (unwind-protect
+      (let ((result ,@body))
+        (list '($bubble) (cons '(mlist) env-name-list) result))
+      (mapcar #'(lambda (env-name)
+                  (let ((env (get env-name 'env)))
+                    (maphash #'(lambda (s v) (setf (gethash s env) (symbol-value s))) env))) ,env-name-list)
       (munbind symbols))))
 
-(defun extract-env-list (car-expr)
-  (let (env-list)
-    (mapcar #'(lambda (x) (if (and (symbolp x) (hash-table-p (get x 'env))) (push (get x 'env) env-list))) car-expr)
-    env-list))
+;; NOT SURE IF FREEOF IS THE APPROPRIATE TEST HERE !!
+(defun freeof-env (e x)
+  (let (symbols)
+    (maphash #'(lambda (s v) (push s symbols)) e)
+    ($lfreeof (cons '(mlist) symbols) x)))
+
+;; HOW IS Z SUPPOSED TO BE USED HERE ??
+(defun simplify-$bubble (x vestigial z)
+  (declare (ignore vestigial))
+  (let
+    ((env-name-list (rest (second x)))
+     (result (third x)))
+    (let ((new-env-name-list (remove-if #'(lambda (e) (freeof-env (get e 'env) result)) env-name-list)))
+      (if (null new-env-name-list)
+        result
+        (list '($bubble simp) (cons '(mlist simp) new-env-name-list) result)))))
+
+(setf (get '$bubble 'operators) 'simplify-$bubble)
+
+(defun extract-env-name-list (car-expr)
+  (let (env-name-list)
+    (mapcar #'(lambda (x) (if (and (symbolp x) (hash-table-p (get x 'env))) (push x env-name-list))) car-expr)
+    (reverse env-name-list)))
 
 (let ((mlambda-prev (symbol-function 'mlambda)))
   (defun mlambda (fn args fnname noeval form)
-    (let ((env-list (extract-env-list (car fn))))
-      (with-lexical-environment env-list (funcall mlambda-prev fn args fnname noeval form)))))
+    (let ((env-name-list (extract-env-name-list (car fn))))
+      (with-lexical-environment env-name-list (funcall mlambda-prev fn args fnname noeval form)))))
 
 (defun mdefine1 (args body)
   (list (append '(lambda) *active-lexical-environments*) (cons '(mlist) args) body))

--- a/robert-dodier/lexical_symbols/with-lexical-environment.lisp
+++ b/robert-dodier/lexical_symbols/with-lexical-environment.lisp
@@ -15,7 +15,7 @@
     (mbind symbols vals nil)
     (unwind-protect
       (let ((result ,@body))
-        (list '($bubble) (cons '(mlist) env-name-list) result))
+        (list '($closure) (cons '(mlist) env-name-list) result))
       (mapcar #'(lambda (env-name)
                   (let ((env (get env-name 'env)))
                     (maphash #'(lambda (s v) (setf (gethash s env) (symbol-value s))) env))) ,env-name-list)
@@ -28,7 +28,7 @@
     ($lfreeof (cons '(mlist) symbols) x)))
 
 ;; HOW IS Z SUPPOSED TO BE USED HERE ??
-(defun simplify-$bubble (x vestigial z)
+(defun simplify-$closure (x vestigial z)
   (declare (ignore vestigial))
   (let
     ((env-name-list (rest (second x)))
@@ -36,9 +36,9 @@
     (let ((new-env-name-list (remove-if #'(lambda (e) (freeof-env (get e 'env) result)) env-name-list)))
       (if (null new-env-name-list)
         result
-        (list '($bubble simp) (cons '(mlist simp) new-env-name-list) result)))))
+        (list '($closure simp) (cons '(mlist simp) new-env-name-list) result)))))
 
-(setf (get '$bubble 'operators) 'simplify-$bubble)
+(setf (get '$closure 'operators) 'simplify-$closure)
 
 (defun extract-env-name-list (car-expr)
   (let (env-name-list)


### PR DESCRIPTION
Implement closures to contain lexical symbols escaping from their defining scope.