### PR TITLE
In DO-TEXIFY, replace aliased symbols before applying TEXIFY.

### DIFF
--- a/robert-dodier/lexical_symbols/rtest_lexical_symbols_only.mac
+++ b/robert-dodier/lexical_symbols/rtest_lexical_symbols_only.mac
@@ -1173,4 +1173,33 @@ b[k]*c[k];
 g3a(b,a);
 a[k]*b[k];
 
+/* https://sourceforge.net/p/maxima/bugs/3684/
+ * originally: https://stackoverflow.com/questions/65064961/maxima-calling-assume-in-a-function
+ */
 
+(kill (foo),
+ myctxt: newcontext (),
+ foo(a, b) := apply('assume, [a < b]),
+ 0)$
+0;
+
+facts();
+[];
+
+foo(0, a);
+[a > 0];
+
+foo(b, a);
+[a > b];
+
+foo(d, c);
+[c > d];
+
+assume(0 < a);
+[redundant];
+
+facts ();
+[a > 0, a > b, c > d];
+
+killcontext (myctxt);
+done;

--- a/yitzchak/texify/texify.lisp
+++ b/yitzchak/texify/texify.lisp
@@ -210,12 +210,19 @@
           (when value
             (return value)))))))
 
+(defun texify-replace-aliases (expr)
+  (cond
+    ((consp expr) (mapcar #'texify-replace-aliases expr))
+    ((symbolp expr) (or (get expr 'reversealias) expr))
+    (t expr)))
+
 (defun do-texify (expr dest modes styles)
   (let* ((*texify-styles* (mapcar (lambda (x) (gethash x texify-styles))
                                  (append styles (cdr $texify_styles))))
+         (expr-no-aliases (texify-replace-aliases expr))
          (result (texify (if (texify-mlabelp expr)
-                           expr
-                           `((mlabel simp) nil ,expr))
+                           expr-no-aliases
+                           `((mlabel simp) nil ,expr-no-aliases))
                          modes)))
     (cond
       ((null dest)


### PR DESCRIPTION
In DO-TEXIFY, replace aliased symbols before applying TEXIFY.

Resolves bug reported to Maxima mailing list 2020-11-28: "texput of derivative"

@yitzchak can I ask you to take a look at this? Maybe there's a better way to implement this. By the way, the bug is triggered by, for example, `orderless(a, b, c); texify(a + b + c);` 