### PR TITLE
New script d00521032-with-For_loop_variables.mac to work with values …

### DIFF
--- a/robert-dodier/distribute_over_tranches/d00521032-with-For_loop_variables.mac
+++ b/robert-dodier/distribute_over_tranches/d00521032-with-For_loop_variables.mac
@@ -1,0 +1,36 @@
+load(lapack);
+
+load ("For_loop_variables.lisp");
+
+load ("distribute_over_tranches.lisp");
+
+DXDT: cartesian_product_list (DX, DT);
+
+t0 : elapsed_real_time ()$
+
+results_flat: distribute_over_tranches ('(block ([dx: DXDT[i][1], dt: DXDT[i][2]], lmax (abs (dgeev (subst ([Δx = dx, Δt = dt], Iteration_matrix))[1])))), i, length (DXDT), 4) $
+
+t1 : elapsed_real_time ()$
+time: t1 - t0;
+
+fpprintprec: 8;
+print ("length(DX) =", length (DX), ", length(DT) =", length (DT));
+print ("length(results_flat) =", length (results_flat));
+ldisplay (results_flat);
+
+/* assemble results matrix from results list */
+
+results_matrix: zeromatrix (length (DX), length (DT)) $
+ij: cartesian_product_list (makelist (i, i, 1, length (DX)), makelist (i, i, 1, length (DT)));
+
+for k thru length (ij)
+    do block ([i, j],
+              [i, j]: ij[k],
+              results_matrix[i, j]: results_flat[k]);
+
+ldisplay (results_matrix);
+
+d: decode_time (absolute_real_time (), 0);
+timestamp: printf (false, "~d-~02,'0d-~02,'0dT-~02,'0d-~02,'0d-~02,'0dZ", d[1], d[2], d[3], d[4], d[5], d[6]);
+session_name: printf (false, "d00521032-with-For_loop_variables-session-~a.lisp", timestamp);
+save (session_name, DXDT, ij, t0, t1, results_flat, results_matrix);

--- a/robert-dodier/distribute_over_tranches/distribute_over_tranches.lisp
+++ b/robert-dodier/distribute_over_tranches/distribute_over_tranches.lisp
@@ -55,8 +55,9 @@
           (if (eql child-pid 0)
             (progn
               (sb-posix:close (first fd-pair))
+              (format t "~d'th child, given indices [~{~d~^, ~}] to process.~%" i indices-to-process)
               (let*
-                ((f (lambda (j) (meval (maxima-substitute (1+ j) expr-loop-var expr))))
+                ((f (lambda (j) (format t "~d'th child: process index ~d~%" i j) (meval (maxima-substitute (1+ j) expr-loop-var expr))))
                  (g (lambda (j) (mfuncall '$string (funcall f j))))
                  (g-f-j (mapcar g indices-to-process))
                  (write-s (lambda (s) (sb-posix:write (second fd-pair) (sb-sys:vector-sap s) (* 4 (length s)))))
@@ -67,6 +68,7 @@
             (progn
               (setf (aref child-pids i) child-pid)
               (sb-posix:close (second fd-pair))
+              (format t "parent: ~d'th child PID = ~d~%" i child-pid)
               (setf (aref read-fds i) (first fd-pair)))))))
 
     (dotimes (i n)


### PR DESCRIPTION
…supplied by For_loop_variables.lisp.

For_loop_variables.lisp is not included in this commit because it is too large (about 80 M). The author posted this link to it: https://drive.google.com/file/d/17fjlTP0FVPuv9VWXDxXgDeWfnB2Qid5d/view?usp=sharing

Incidentally output some progress messages in distribute_over_tranches.lisp.

d00521032-with-For_loop_variables.mac saves the results (via 'save') to a file named d00521032-with-For_loop_variables-session-yyyy-mm-ddThh-mm-ssZ.lisp where yyyy-mm-ddThh-mm-ssZ is a timestamp for the current time in UTC.